### PR TITLE
Fix repo URL (the repo is case sensitive; it appears)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-facebook",
   "version": "0.1.0",
-  "homepage": "https://github.com/Ciul/Angularjs-Facebook",
+  "homepage": "https://github.com/Ciul/angularjs-facebook",
   "authors": [
     "Luis Carlos Osorio Jayk <luiscarlosjayk@gmail.com>"
   ],


### PR DESCRIPTION
Can't install using bower.

```
$ bower install angularjs-facebook
bower not-cached    git://github.com/Ciul/Angularjs-Facebook.git#*
bower resolve       git://github.com/Ciul/Angularjs-Facebook.git#*
bower ECMDERR       Failed to execute "git ls-remote --tags --heads git://github.com/Ciul/Angularjs-Facebook.git", exit code of #128

Additional error details:
fatal: remote error:
  Repository not found.
```
