### PR TITLE
Adding https:// to the src if the users loads the script from the local storage

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -364,6 +364,11 @@ provides: [facebook]
     script = document.createElement('script');
     script.id = 'facebook-jssdk';
     script.async = true;
+
+    if ($window.location.protocol === 'file:') {
+        src = 'https:' + src;
+    }
+
     script.src = src;
     document.getElementsByTagName('head')[0].appendChild(script); // Fix for IE < 9, and yet supported by lattest browsers
   }]);


### PR DESCRIPTION
This plugin injects the Facebook script with
`var src     = '//connect.facebook.net/'.concat(settings.locale, '/all.js'),`

It'd be useful if it verifies if the user is accessing locally (by the file:/ protocol).

I'm developing a Cordova / PhoneGap hybrid app and should this plugin, but as it is the facebook extension fails to load and by the iOS development guidelines I should load my logic locally, so I can't just use a remote page to solve this (and make the app update without the App Store and so on).
