### PR TITLE
Adding a setting to control the SDK loading

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -169,6 +169,19 @@ provides: [facebook]
         };
 
         /**
+         * Load SDK
+         */
+        settings.loadSdk = true;
+
+        this.setLoadSdk = function(a) {
+          settings.loadSdk = !!a;
+        }
+
+        this.getLoadSdk = function() {
+          return settings.loadSdk;
+        }
+
+        /**
          * Custom option setting
          * key @type {String}
          * value @type {*}
@@ -472,7 +485,7 @@ provides: [facebook]
         /**
          * SDK script injecting
          */
-        (function injectScript() {
+        settings.loadSdk && (function injectScript() {
           var src           = '//connect.facebook.net/' + settings.locale + '/all.js',
               script        = document.createElement('script');
               script.id     = 'facebook-jssdk';


### PR DESCRIPTION
This pull request adds a new setting called `loadSdk`.

When the loadSdk setting is truthy (the default), the FB SDK will load during the run phase of the module. When the loadSdk setting is falsy, the SDK will not load and may be loaded manually.

If you're interested in the changes, that would be great! The intention for this change is to allow loading of the SDK to be done manually (for example, to load the SDK after phonegap's deviceready event).

Best,
 -Eric
