### PR TITLE
Repaired bug in api call FB.XFBML.parse

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -329,7 +329,7 @@ provides: [facebook]
               $timeout(function() {
                 // Call when loadDeferred be resolved, meaning Service is ready to be used
                 loadDeferred.promise.then(function() {
-                  $window.FB.parse();
+                  $window.FB.XFBML.parse();
                   d.resolve();
                 }, function() {
                   throw 'Facebook API could not be initialized properly';


### PR DESCRIPTION
The actual name of the method called to parse Facebook Social Plugins elements is FB.XFBML.parse , not FB.parse.
See: https://developers.facebook.com/docs/reference/javascript/FB.XFBML.parse/
