### PR TITLE
Refactor login() method to invoke FB.login() synchronously. Fixes issue ...

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -263,11 +263,54 @@ provides: [facebook]
               return flags.ready;
             };
 
+            NgFacebook.prototype.login = function () {
+
+              var d = $q.defer(),
+                  args = Array.prototype.slice.call(arguments),
+                  userFn,
+                  userFnIndex; // Converts arguments passed into an array
+
+                // Get user function and it's index in the arguments array, to replace it with custom function, allowing the usage of promises
+                angular.forEach(args, function(arg, index) {
+                  if (angular.isFunction(arg)) {
+                    userFn = arg;
+                    userFnIndex = index;
+                  }
+                });
+
+                // Replace user function intended to be passed to the Facebook API with a custom one
+                // for being able to use promises.
+                if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
+                  args.splice(userFnIndex, 1, function(response) {
+                    $timeout(function() {
+                      if (angular.isUndefined(response.error)) {
+                        d.resolve(response);
+                      } else {
+                        d.reject(response);
+                      }
+
+                      if (angular.isFunction(userFn)) {
+                        userFn(response);
+                      }
+                    });
+                  });
+                }
+
+                if (this.isReady()) {
+                  $window.FB.login.apply($window.FB, args);
+                } else {
+                  $timeout(function() {
+                    d.reject("Facebook.login() called before Facebook SDK has loaded.");
+                  });
+                }
+
+                return d.promise;
+            };
+
             /**
              * Map some asynchronous Facebook sdk methods to NgFacebook
              */
             angular.forEach([
-              'login',
               'logout',
               'api',
               'ui',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-facebook",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An AngularJS module to take approach of the Facebook Javascript SDK.",
   "main": "lib/angular-facebook.js",
   "directories": {


### PR DESCRIPTION
Fixes #24 by placing calls to `FB.login` outside of asynchronous `$timeout` calls.
