### PR TITLE
Add checks in some places to see if a response doesn't exist

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -293,10 +293,12 @@ provides: [facebook]
                 if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
                   args.splice(userFnIndex, 1, function(response) {
                     $timeout(function() {
-                      if (angular.isUndefined(response.error)) {
-                        d.resolve(response);
-                      } else {
-                        d.reject(response);
+                      if (typeof response !== 'undefined') {
+                        if (typeof response.error === 'undefined') {
+                          d.resolve(response);
+                        } else {
+                          d.reject(response);
+                        }
                       }
 
                       if (angular.isFunction(userFn)) {
@@ -363,10 +365,12 @@ provides: [facebook]
               if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
                 args.splice(userFnIndex, 1, function(response) {
                   $timeout(function() {
-                    if (angular.isUndefined(response.error)) {
-                      d.resolve(response);
-                    } else {
-                      d.reject(response);
+                    if (typeof response !== 'undefined') {
+                      if (typeof response.error === 'undefined') {
+                        d.resolve(response);
+                      } else {
+                        d.reject(response);
+                      }
                     }
 
                     if (angular.isFunction(userFn)) {
@@ -412,10 +416,12 @@ provides: [facebook]
               if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
                 args.splice(userFnIndex, 1, function(response) {
                   $timeout(function() {
-                    if (angular.isUndefined(response.error)) {
-                      d.resolve(response);
-                    } else {
-                      d.reject(response);
+                    if (typeof response !== 'undefined') {
+                      if (typeof response.error === 'undefined') {
+                        d.resolve(response);
+                      } else {
+                        d.reject(response);
+                      }
                     }
 
                     if (angular.isFunction(userFn)) {


### PR DESCRIPTION
Error that pops up to when you have a callback to an FB.ui method to check for a response, as suggested in the docs: https://developers.facebook.com/docs/sharing/reference/share-dialog

If a user clicks 'cancel' or exits out of a share dialog, the response seems to be undefined. there's an error that says "cannot read property 'error' of undefined."

This seems to fix it.
