### PR TITLE
Added check if FB SDK has already loaded on page, otherwise fbAsyncInit ...

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -469,48 +469,55 @@
         delete(settings['loadSDK']); // Remove loadSDK from settings since this isn't part from Facebook API.
 
         /**
-         * Define fbAsyncInit required by Facebook API
-         */
-        $window.fbAsyncInit = function() {
-          // Initialize our Facebook app
-          $timeout(function() {
-            if (!settings.appId) {
-              throw 'Missing appId setting.';
-            }
+        * Define fbAsyncInit required by Facebook API
+        */
+        function init() {
+            // Initialize our Facebook app
+            $timeout(function() {
+              if (!settings.appId) {
+                  throw 'Missing appId setting.';
+              }
 
-            FB.init(settings);
+              FB.init(settings);
 
-            flags.ready = true;
+              // Set ready global flag
+              flags.ready = true;
 
-            /**
-             * Subscribe to Facebook API events and broadcast through app.
-             */
-            angular.forEach({
-              'auth.login': 'login',
-              'auth.logout': 'logout',
-              'auth.prompt': 'prompt',
-              'auth.sessionChange': 'sessionChange',
-              'auth.statusChange': 'statusChange',
-              'auth.authResponseChange': 'authResponseChange',
-              'xfbml.render': 'xfbmlRender',
-              'edge.create': 'like',
-              'edge.remove': 'unlike',
-              'comment.create': 'comment',
-              'comment.remove': 'uncomment'
-            }, function(mapped, name) {
-              FB.Event.subscribe(name, function(response) {
-                $timeout(function() {
-                  $rootScope.$broadcast('Facebook:' + mapped, response);
-                });
+              /**
+               * Subscribe to Facebook API events and broadcast through app.
+               */
+              angular.forEach({
+                  'auth.login': 'login',
+                  'auth.logout': 'logout',
+                  'auth.prompt': 'prompt',
+                  'auth.sessionChange': 'sessionChange',
+                  'auth.statusChange': 'statusChange',
+                  'auth.authResponseChange': 'authResponseChange',
+                  'xfbml.render': 'xfbmlRender',
+                  'edge.create': 'like',
+                  'edge.remove': 'unlike',
+                  'comment.create': 'comment',
+                  'comment.remove': 'uncomment'
+              }, function(mapped, name) {
+                  FB.Event.subscribe(name, function(response) {
+                      $timeout(function() {
+                          $rootScope.$broadcast('Facebook:' + mapped, response);
+                      });
+                  });
               });
+
+              // Broadcast Facebook:load event
+              $rootScope.$broadcast('Facebook:load');
+
+              loadDeferred.resolve(FB);
             });
-
-            // Broadcast Facebook:load event
-            $rootScope.$broadcast('Facebook:load');
-
-            loadDeferred.resolve(FB);
-          });
-        };
+        }
+        // Check if FB SDK has already loaded
+        if(typeof $window.FB !== 'undefined') {
+            init();
+        } else {
+            $window.fbAsyncInit = init;
+        }
 
         /**
          * Inject Facebook root element in DOM


### PR DESCRIPTION
Hi, 
Thanks for all your work on this I've found it really helpful. I noticed in some instances possibly when the SDK is cached locally that $window.fbAsyncInit is called before it's declared below. Meaning the FB SDK will never trigger the initialisation of this class.

I've just added a small check to see if the FB SDK already exists then just init directly. Hope that makes sense. Sorry this is my first pull request, let me know if I can help in any other way.

Thanks again,
Charlie
