### PR TITLE
Fix bug when Facebook library fails to load

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -217,6 +217,13 @@
         this.getSdkVersion = function() {
           return settings.version;
         };
+        
+        /**
+         * Library Failure Timeout
+         */
+        this.setFailureTimeout = function(value) {
+          settings.failureTimeout = value;
+        };
 
         /**
          * Init Facebook API required stuff
@@ -364,6 +371,8 @@
                   // Call when loadDeferred be resolved, meaning Service is ready to be used.
                   loadDeferred.promise.then(function() {
                     $window.FB[name].apply(FB, args);
+                  }, function() {
+                    d.reject('Facebook API failed to initialize');
                   });
                 });
 
@@ -553,6 +562,14 @@
             // Fix for IE < 9, and yet supported by latest browsers
             document.getElementsByTagName('head')[0].appendChild(script);
           })();
+        }
+        
+        // Reject loadDeferred after a timeout
+        // If the library is loaded before the timeout, the reject won't affect as promises are resolved only once
+        if (settings.failureTimeout) {
+          $timeout(function() {
+            loadDeferred.reject();
+          }, settings.failureTimeout);
         }
       }
     ]);


### PR DESCRIPTION
Add timeout support, to reject promise when Facebook library fails to load. This is needed when Facebook domain/host is blocked in the current network or Facebook is down (unlikely, but it can happen).