### PR TITLE
Added FB Canvas autogrow

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-facebook-intren",
   "version": "0.2.4",
-  "homepage": "https://github.com/Ciul/angularjs-facebook",
+  "homepage": "https://github.com/bajzarpa/angular-facebook",
   "authors": [
     "Luis Carlos Osorio Jayk <luiscarlosjayk@gmail.com>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "angular-facebook",
-  "version": "0.2.3",
+  "name": "angular-facebook-intren",
+  "version": "0.2.4",
   "homepage": "https://github.com/Ciul/angularjs-facebook",
   "authors": [
     "Luis Carlos Osorio Jayk <luiscarlosjayk@gmail.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "angular-facebook-intren",
-  "version": "0.2.4",
-  "homepage": "https://github.com/bajzarpa/angular-facebook",
+  "name": "angular-facebook",
+  "version": "0.2.3",
+  "homepage": "https://github.com/Ciul/angularjs-facebook",
   "authors": [
     "Luis Carlos Osorio Jayk <luiscarlosjayk@gmail.com>"
   ],

--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -480,6 +480,8 @@
 
             FB.init(settings);
 
+            FB.Canvas.setAutoGrow();
+
             flags.ready = true;
 
             /**


### PR DESCRIPTION
I've used the library in a Facebook tab, and there were no option for set the Canvas height. I placed the Facebook AutoGrow option after the init. This is has no effect when you don't use canvas and or tab.