### PR TITLE
Fix for #123: Callback functions now work correctly without a callback

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -285,15 +285,16 @@
                   }
                 });
 
-                // If there was no user function, set its index to the number of args
-                // So that a new callback can be added to the end
+                // If there was no user function, set its index to 0
+                // So that a new callback can be prepended to the arguments list
                 if (!angular.isNumber(userFnIndex)) {
-                  userFnIndex = args.length;
+                  userFnIndex = 0;
                 }
 
                 // Replace user function intended to be passed to the Facebook API with a custom one
                 // for being able to use promises.
-                args.splice(userFnIndex, 1, function(response) {
+                // If there was no userFn, we don't want to remove any other parameters
+                args.splice(userFnIndex, (angular.isFunction(userFn)) ? 1 : 0, function(response) {
                   $timeout(function() {
 
                     if (response && angular.isUndefined(response.error)) {

--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -285,24 +285,28 @@
                   }
                 });
 
+                // If there was no user function, set its index to the number of args
+                // So that a new callback can be added to the end
+                if (!angular.isNumber(userFnIndex)) {
+                  userFnIndex = args.length;
+                }
+
                 // Replace user function intended to be passed to the Facebook API with a custom one
                 // for being able to use promises.
-                if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
-                  args.splice(userFnIndex, 1, function(response) {
-                    $timeout(function() {
+                args.splice(userFnIndex, 1, function(response) {
+                  $timeout(function() {
 
-                      if (response && angular.isUndefined(response.error)) {
-                        d.resolve(response);
-                      } else {
-                        d.reject(response);
-                      }
+                    if (response && angular.isUndefined(response.error)) {
+                      d.resolve(response);
+                    } else {
+                      d.reject(response);
+                    }
 
-                      if (angular.isFunction(userFn)) {
-                        userFn(response);
-                      }
-                    });
+                    if (angular.isFunction(userFn)) {
+                      userFn(response);
+                    }
                   });
-                }
+                });
 
                 // review(mrzmyr): generalize behaviour of isReady check
                 if (this.isReady()) {
@@ -341,24 +345,28 @@
                   }
                 });
 
+                // If there was no user function, set its index to the number of args
+                // So that a new callback can be added to the end
+                if (!angular.isNumber(userFnIndex)) {
+                  userFnIndex = args.length;
+                }
+
                 // Replace user function intended to be passed to the Facebook API with a custom one
                 // for being able to use promises.
-                if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
-                  args.splice(userFnIndex, 1, function(response) {
-                    $timeout(function() {
+                args.splice(userFnIndex, 1, function(response) {
+                  $timeout(function() {
 
-                      if (response && angular.isUndefined(response.error)) {
-                        d.resolve(response);
-                      } else {
-                        d.reject(response);
-                      }
+                    if (response && angular.isUndefined(response.error)) {
+                      d.resolve(response);
+                    } else {
+                      d.reject(response);
+                    }
 
-                      if (angular.isFunction(userFn)) {
-                        userFn(response);
-                      }
-                    });
+                    if (angular.isFunction(userFn)) {
+                      userFn(response);
+                    }
                   });
-                }
+                });
 
                 $timeout(function() {
                   // Call when loadDeferred be resolved, meaning Service is ready to be used.
@@ -415,25 +423,29 @@
                   }
                 });
 
+                // If there was no user function, set its index to the number of args
+                // So that a new callback can be added to the end
+                if (!angular.isNumber(userFnIndex)) {
+                  userFnIndex = args.length;
+                }
+
                 // Replace user function intended to be passed to the Facebook API with a custom one
                 // for being able to use promises.
-                if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
-                  args.splice(userFnIndex, 1, function(response) {
+                args.splice(userFnIndex, 1, function(response) {
 
-                    $timeout(function() {
+                  $timeout(function() {
 
-                      if (response && angular.isUndefined(response.error)) {
-                        d.resolve(response);
-                      } else {
-                        d.reject(response);
-                      }
+                    if (response && angular.isUndefined(response.error)) {
+                      d.resolve(response);
+                    } else {
+                      d.reject(response);
+                    }
 
-                      if (angular.isFunction(userFn)) {
-                        userFn(response);
-                      }
-                    });
+                    if (angular.isFunction(userFn)) {
+                      userFn(response);
+                    }
                   });
-                }
+                });
 
                 $timeout(function() {
                   // Call when loadDeferred be resolved, meaning Service is ready to be used


### PR DESCRIPTION
Fixes #123 
Previously, if you called one of the login() or getLoginStatus() etc. without a callback, a promise was not returned and therefore you could not use the promise api. Now, if a callback function could not be found in the args array, the response function is simply concatenated onto the end of the other arguments.
